### PR TITLE
feature/SM-6813: Add organisation status to response interfaces

### DIFF
--- a/dist/interfaces/organisationSummaryResponse.d.ts
+++ b/dist/interfaces/organisationSummaryResponse.d.ts
@@ -1,4 +1,7 @@
+import { OrganisationStatusResponse } from './referenceTypes';
 export interface OrganisationSummaryResponse {
     name: string;
     organisation_reference: string;
+    organisation_status?: OrganisationStatusResponse;
+    organisation_status_string?: string;
 }

--- a/dist/interfaces/referenceTypes.d.ts
+++ b/dist/interfaces/referenceTypes.d.ts
@@ -57,3 +57,9 @@ export declare enum WorkstreamAccessLevelResponse {
     read_only = "read_only",
     upcoming_enum = "upcoming_enum"
 }
+export declare enum OrganisationStatusResponse {
+    active = "active",
+    suspended = "suspended",
+    disabled = "disabled",
+    upcoming_enum = "upcoming_enum"
+}

--- a/dist/interfaces/referenceTypes.js
+++ b/dist/interfaces/referenceTypes.js
@@ -69,3 +69,10 @@ var WorkstreamAccessLevelResponse;
     WorkstreamAccessLevelResponse["read_only"] = "read_only";
     WorkstreamAccessLevelResponse["upcoming_enum"] = "upcoming_enum";
 })(WorkstreamAccessLevelResponse = exports.WorkstreamAccessLevelResponse || (exports.WorkstreamAccessLevelResponse = {}));
+var OrganisationStatusResponse;
+(function (OrganisationStatusResponse) {
+    OrganisationStatusResponse["active"] = "active";
+    OrganisationStatusResponse["suspended"] = "suspended";
+    OrganisationStatusResponse["disabled"] = "disabled";
+    OrganisationStatusResponse["upcoming_enum"] = "upcoming_enum";
+})(OrganisationStatusResponse = exports.OrganisationStatusResponse || (exports.OrganisationStatusResponse = {}));

--- a/dist/interfaces/userResponse.d.ts
+++ b/dist/interfaces/userResponse.d.ts
@@ -1,4 +1,4 @@
-import { RoleResponse } from './referenceTypes';
+import { OrganisationStatusResponse, RoleResponse } from './referenceTypes';
 import { OrganisationSummaryResponse } from './organisationSummaryResponse';
 import { UserWorkstreamAccessResponse } from './userWorkstreamAccess';
 export interface UserWorkstreamAccessDetails extends UserWorkstreamAccessResponse {
@@ -14,4 +14,6 @@ export interface UserResponse {
     organisation_reference: string;
     contracts?: OrganisationSummaryResponse[];
     workstreams?: UserWorkstreamAccessDetails[];
+    organisation_status?: OrganisationStatusResponse;
+    organisation_status_string?: string;
 }

--- a/src/interfaces/organisationSummaryResponse.ts
+++ b/src/interfaces/organisationSummaryResponse.ts
@@ -1,4 +1,8 @@
+import { OrganisationStatusResponse } from './referenceTypes'
+
 export interface OrganisationSummaryResponse {
   name: string
   organisation_reference: string
+  organisation_status?: OrganisationStatusResponse
+  organisation_status_string?: string
 }

--- a/src/interfaces/referenceTypes.ts
+++ b/src/interfaces/referenceTypes.ts
@@ -66,3 +66,10 @@ export enum WorkstreamAccessLevelResponse {
   read_only = 'read_only',
   upcoming_enum = 'upcoming_enum'
 }
+
+export enum OrganisationStatusResponse {
+  active = 'active',
+  suspended = 'suspended',
+  disabled = 'disabled',
+  upcoming_enum = 'upcoming_enum'
+}

--- a/src/interfaces/userResponse.ts
+++ b/src/interfaces/userResponse.ts
@@ -1,4 +1,4 @@
-import { RoleResponse } from './referenceTypes'
+import { OrganisationStatusResponse, RoleResponse } from './referenceTypes'
 import { OrganisationSummaryResponse } from './organisationSummaryResponse'
 import { UserWorkstreamAccessResponse } from './userWorkstreamAccess'
 
@@ -16,4 +16,6 @@ export interface UserResponse {
   organisation_reference: string
   contracts?: OrganisationSummaryResponse[]
   workstreams?: UserWorkstreamAccessDetails[]
+  organisation_status?: OrganisationStatusResponse
+  organisation_status_string?: string
 }


### PR DESCRIPTION
## Description

Add optional organisation_status and organisation_status_string properties to UserResponse and OrganisationSummaryResponse

Party Client: https://github.com/departmentfortransport/street-manager-party-client/pull/68
Party API: https://github.com/departmentfortransport/street-manager-party-api/pull/224
Frontend: https://github.com/departmentfortransport/street-manager-frontend/pull/1627

## Coding Standards

Style guide: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Style-Guide
Coding best practices: https://github.com/departmentfortransport/street-manager/wiki/Street-Manager-Coding-Best-Practices

## Checklist

- [ ] Branch named {feature|hotfix|task}/{SM-.*}
- [ ] If your pull request depends on any other, please link them
- [ ] Changes approved by your team
- [ ] Changes approved by another team
- [ ] API definitions updated
- [ ] Commit messages are meaningful
- [ ] Int UI tests passing https://circleci.com/gh/departmentfortransport/street-manager-int/tree/master
- [ ] Add `DO NOT MERGE` if you want to postpone merge
